### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,14 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-KEYWORD1    SHT35
+KEYWORD1	SHT35
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-KEYWORD2    init
-KEYWORD2    read_meas_data_single_shot
+KEYWORD2	init
+KEYWORD2	read_meas_data_single_shot
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords