### PR TITLE
Fix casing for Arduino.h include

### DIFF
--- a/Seeed_SHT35.h
+++ b/Seeed_SHT35.h
@@ -32,7 +32,7 @@
 #ifndef _SEEED_SHT35_H
 #define _SEEED_SHT35_H
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "Wire.h"
 
 


### PR DESCRIPTION
The current version of the library does not compile on Linux because Arduino.h is written with an uppercase A. This commit corrects the include statement.