### PR TITLE
Fixed Mega 2560 bootloader going into Monitor mode

### DIFF
--- a/examples/basic_demo/basic_demo.ino
+++ b/examples/basic_demo/basic_demo.ino
@@ -53,7 +53,7 @@ void setup() {
     delay(10);
     SERIAL.println("serial start!!");
     if (sensor.init()) {
-        SERIAL.println("sensor init failed!!!");
+        SERIAL.println("sensor init failed!!");
     }
     delay(1000);
 }


### PR DESCRIPTION
On Mega 2560 devices, three exclamation marks in a row (!!!) causes the device to go into Monitor mode. In this case, when uploading code from the Arduino IDE you will get an **_avrdude: stk500v2_ReceiveMessage(): timeout_** error (the device is expecting input).

To fix this, I removed one exclamation mark.

See [here](https://stackoverflow.com/questions/19645441/avrdude-stk500v2-receivemessage-timeout) for more details
